### PR TITLE
temporary fix to hdxclosestpairsrecav that doesn't break the webpage

### DIFF
--- a/HighwayDataExaminer/hdxclosestpairsrecav.js
+++ b/HighwayDataExaminer/hdxclosestpairsrecav.js
@@ -31,7 +31,7 @@ var hdxClosestPairsRecAV = {
     whileLoopIndex: 0,
     returnValue: 0,
 
-    originalWaypoints: null,
+    originalWaypoints: waypoints.slice(),
     //vertices sorted by longitude
     WtoE: null,
     //vertices sorted by latitude
@@ -54,6 +54,7 @@ var hdxClosestPairsRecAV = {
     lineClosest: null,
     lineFarthest: null,
     lineVisiting: null,
+    lineStack: null,
     
     // the actions that make up this algorithm
     avActions: [
@@ -677,10 +678,10 @@ var hdxClosestPairsRecAV = {
 
         //reorder waypoints
         let presort = new HDXPresort();
-        this.originalWaypoints = waypoints;
+        this.originalWaypoints = waypoints.slice();
         this.waypoints = presort.sortedWaypoints;
         hdxClosestPairsRecAV.WtoE = this.waypoints;
-        updateMap();
+        //updateMap();
 
         // show waypoints, hide connections
         initWaypointsAndConnections(true, false,
@@ -741,7 +742,7 @@ var hdxClosestPairsRecAV = {
 	if (this.lineFarthest != null) {
 	    this.lineFarthest.remove();
 	}
-	while (!this.lineStack.isEmpty()) {
+	while (this.lineStack != null && !this.lineStack.isEmpty()) {
 	    // remove from stack, returned result remove from map
 	    this.lineStack.remove().remove();
 	}


### PR DESCRIPTION
The current version on hdxt as of writing this has an issue that was worse than before where the AV just completely breaks everything. This is a result of the cleanupui function potentially calling a method on a null if Start is not pressed, and errors due to calling the updateMap() function. This fix still does not change the computational bug, but after a webpage refresh its fine for now.