### PR TITLE
Relative linking #571

### DIFF
--- a/HighwayDataExaminer/hdxjsfuncs.js
+++ b/HighwayDataExaminer/hdxjsfuncs.js
@@ -320,16 +320,16 @@ function HDXReadFileFromWebServer(graphName) {
 
     hdxGlobals.loadingFile = graphName;
     // check what we're loading, to find the right location
-    let urlPath = "https://courses.teresco.org/metal/graphdata/";
+    let urlPath = "/metal/graphdata/";
     if (hdxGlobals.graphSet != "current") {
-	urlPath = "https://courses.teresco.org/metal/grapharchives/" +
+	urlPath = "/metal/grapharchives/" +
 	    hdxGlobals.graphSet + "/";
     }
     if (graphName == "tm-master.nmp") {
-	urlPath = "https://courses.teresco.org/metal/tmlogs/";
+	urlPath = "/metal/tmlogs/";
     }
     else if (graphName.endsWith(".nmp")) {
-	urlPath = "https://courses.teresco.org/metal/tmlogs/nmpbyregion/";
+	urlPath = "/metal/tmlogs/nmpbyregion/";
     }
     // open and send the AJAX request, on completion the HDXFileLoadedCallback
     // function will handle the results

--- a/HighwayDataExaminer/hdxmenufuncs.js
+++ b/HighwayDataExaminer/hdxmenufuncs.js
@@ -417,6 +417,6 @@ function HDXCreateDefaultGraphSelectionMenu() {
     
     const help = document.createElement("p");
     help.setAttribute("class", "descr");
-    help.innerHTML = "Need help?  HDX tips can be found <a href='/metal/tips.html' target='_blank'>here</a>.";
+    help.innerHTML = "Need help?  HDX tips can be found <a href='https://course.teresco.org/metal/tips.html' target='_blank'>here</a>.";
     mainbox.appendChild(help);
 }

--- a/HighwayDataExaminer/hdxmenufuncs.js
+++ b/HighwayDataExaminer/hdxmenufuncs.js
@@ -417,6 +417,6 @@ function HDXCreateDefaultGraphSelectionMenu() {
     
     const help = document.createElement("p");
     help.setAttribute("class", "descr");
-    help.innerHTML = "Need help?  HDX tips can be found <a href='https://courses.teresco.org/metal/tips.html' target='_blank'>here</a>.";
+    help.innerHTML = "Need help?  HDX tips can be found <a href='/metal/tips.html' target='_blank'>here</a>.";
     mainbox.appendChild(help);
 }

--- a/HighwayDataExaminer/hdxmenufuncs.js
+++ b/HighwayDataExaminer/hdxmenufuncs.js
@@ -417,6 +417,6 @@ function HDXCreateDefaultGraphSelectionMenu() {
     
     const help = document.createElement("p");
     help.setAttribute("class", "descr");
-    help.innerHTML = "Need help?  HDX tips can be found <a href='https://course.teresco.org/metal/tips.html' target='_blank'>here</a>.";
+    help.innerHTML = "Need help?  HDX tips can be found <a href='https://courses.teresco.org/metal/tips.html' target='_blank'>here</a>.";
     mainbox.appendChild(help);
 }

--- a/HighwayDataExaminer/index.php
+++ b/HighwayDataExaminer/index.php
@@ -98,7 +98,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css"/>
 <link rel="stylesheet" type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"/>
-<link rel="stylesheet" type="text/css" href="https://travelmapping.net/css/travelMapping.css"/>
+<link rel="stylesheet" type="text/css" href="tm/css/travelMapping.css"/>
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="hdx.css" />
 


### PR DESCRIPTION
I have changed all of the links to not be hard coded to travelmapping.net or courses.teresco.org, with the only exception being for the help page. This way versions not hosted on courses.teresco.org will have the same help information

--New dependency--
new shortcut needed in the hdx directory called "tm" which maps to the travelmapping directory