### PR TITLE
Updated php tags in two files

### DIFF
--- a/HighwayDataExaminer/generateGraphList.php
+++ b/HighwayDataExaminer/generateGraphList.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // read information about graphs from our DB
 $params = json_decode($_POST['params'], true);
 

--- a/HighwayDataExaminer/generateSimpleGraphList.php
+++ b/HighwayDataExaminer/generateSimpleGraphList.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // read information about graphs from our DB
 $params = json_decode($_POST['params'], true);
 


### PR DESCRIPTION
updated generateGraphList and generateSimpleGraphList to use full php tags instead of the short tags. This is due to some versions of php requiring the full tag and not the short tag.