### PR TITLE
Updated AV Selection Menu Text & Fixed Bug on GAPT

### DIFF
--- a/HighwayDataExaminer/hdxav-gapt.js
+++ b/HighwayDataExaminer/hdxav-gapt.js
@@ -137,6 +137,7 @@ const hdxGAPTAV = {
 				document.getElementById("found").innerText="Number of traversals: "+thisAV.traversals.length;
 				document.getElementById("foundEntries").appendChild(newPath);
 				
+                hdxAV.iterationDone = true;
                 if(thisAV.callStack.length>0){
 					hdxAV.nextAction = "collectArr";
 				}else{

--- a/HighwayDataExaminer/hdxav.js
+++ b/HighwayDataExaminer/hdxav.js
@@ -185,7 +185,7 @@ const hdxAV = {
         const outerDetails = document.createElement("details");
         outerDetails.open = false;
         const outerSummary = document.createElement("summary");
-        outerSummary.textContent = "Algorithm Categories";
+        outerSummary.textContent = hdxNoAV.name;
         outerDetails.appendChild(outerSummary);
         s.appendChild(outerDetails);
 
@@ -213,11 +213,12 @@ const hdxAV = {
             item.onclick = (function(val) {
                 return function() {
                 	hdxAV.selectAlgorithmByValue(val);
-                	outerDetails.open=false;
+                	outerSummary.textContent = av.name;
                 	const algGroups = document.querySelectorAll("details");
                 	algGroups.forEach(function(event){
                 		event.open=false;
                 	});
+                	outerDetails.open=false;
                 };
             })(av.value);
             if (currentGroupDiv !== null) {


### PR DESCRIPTION
AV Selection menu text now says No Algorithm Visualization when page is loaded and updates to the new AV name when a new AV is selected.

hdxav-gapt can now be run using x updates per second.