### PR TITLE
Resolves Issues #553, #586 #484 & #491

### DIFF
--- a/HighwayDataExaminer/hdxav-clickDis.js
+++ b/HighwayDataExaminer/hdxav-clickDis.js
@@ -400,7 +400,9 @@ const hdxClickDisAV = {
     // removing map changes
     cleanupUI() {
         this.marker.remove();
-        this.circle.remove();
+        if(this.findVertices!="SLDistance"){
+        	this.circle.remove();
+        }
     },
     idOfAction(action) {
 	

--- a/HighwayDataExaminer/hdxav-clickDis.js
+++ b/HighwayDataExaminer/hdxav-clickDis.js
@@ -251,6 +251,7 @@ const hdxClickDisAV = {
                 code: function(thisAV) {
                 	highlightPseudocode(this.label, visualSettings.visiting);
                     
+                    thisAV.vertexStatus=true;
                     let i=0;
                     while(i<thisAV.computedDistances.length && thisAV.currentDistance>thisAV.computedDistances[i][1]){
                     	i++;

--- a/HighwayDataExaminer/hdxav-gapt.js
+++ b/HighwayDataExaminer/hdxav-gapt.js
@@ -33,6 +33,8 @@ const hdxGAPTAV = {
 	
     // loop variable that tracks which point is currently being operated upon
     nextToCheck: -1,
+    
+    gradient: new Rainbow(),
 
     // The avActions array defines all of the actions of the AV
     avActions : [
@@ -52,6 +54,9 @@ const hdxGAPTAV = {
                 thisAV.availableVertices=hdxGAPTAV.newAvailableVertices(thisAV.availableVertices, thisAV.usedVertices, getAdjacentPoints(thisAV.usedVertices[0]));
             	thisAV.callStack = [];
                 thisAV.nextToCheck = -1;
+                
+                //Vertex colors on hover in AVCP
+                thisAV.gradiant = new Rainbow();
             
                 hdxAV.nextAction = "topOfFunction";
             },
@@ -132,7 +137,7 @@ const hdxGAPTAV = {
 						traversalStr += ", " + thisAV.usedVertices[i];
 					}
 				}
-				newPath.innerHTML='<td style="background-color:white; color:black;"><center>'+traversalStr+'</center></td>';
+				newPath.innerHTML='<td style="background-color:white; color:black;" onmouseover="hdxGAPTAV.traversalAVCPHover('+thisAV.traversals.length+')" onmouseout="hdxGAPTAV.resetVs()"><center>'+traversalStr+'</center></td>';
 				thisAV.traversals.push(thisAV.usedVertices);
 				document.getElementById("found").innerText="Number of traversals: "+thisAV.traversals.length;
 				document.getElementById("foundEntries").appendChild(newPath);
@@ -168,10 +173,10 @@ const hdxGAPTAV = {
 					updateMarkerAndTable(thisAV.usedVertices[i],
 				    	visualSettings.discovered, 30, false);
 				}
-				updateMarkerAndTable(thisAV.usedVertices[0],
-				     visualSettings.startVertex, 30, false);
 				updateMarkerAndTable(thisAV.usedVertices[thisAV.usedVertices.length-1],
 				     visualSettings.visiting, 30, false);
+				updateMarkerAndTable(thisAV.usedVertices[0],
+				     visualSettings.startVertex, 30, false);
 
 				if(thisAV.loopIteration<thisAV.availableVertices.length-1){
 					hdxAV.nextAction = "topOfLoop";
@@ -293,5 +298,27 @@ const hdxGAPTAV = {
     	}
     	newTraversal.push(currentVertice)
     	return newTraversal;
+    },
+    
+    // Resets the vertex colors after hover off
+    resetVs(){
+    	for(i=0; i<waypoints.length;i++){
+    		updateMarkerAndTable(i, visualSettings.undiscovered, 30, false);
+    	}
+    	updateMarkerAndTable(hdxGAPTAV.usedVertices[0], visualSettings.startVertex, 30, false)
+    },
+    traversalAVCPHover(travNum){
+    	this.gradiant.setNumberRange(0,this.traversals[travNum].length-1);
+    	for(i=0; i<this.traversals[travNum].length;i++){
+    		updateMarkerAndTable(this.traversals[travNum][i], {
+                color: "#" + this.gradiant.colorAt(i),
+        		textColor: "white",
+        		scale: 8,
+        		name: "visiting",
+        		value: 0,
+        		weight: 8,
+        		opacity: 1
+            }, 30, false);
+    	}
     }
 }

--- a/HighwayDataExaminer/hdxav-none.js
+++ b/HighwayDataExaminer/hdxav-none.js
@@ -25,9 +25,6 @@ const hdxNoAV = {
     },
 
     setupUI() {
-    	if(location.search.includes("none")){
-    		algOptionsDonePressed();
-    	}
 
     },
 

--- a/HighwayDataExaminer/hdxav-none.js
+++ b/HighwayDataExaminer/hdxav-none.js
@@ -25,6 +25,9 @@ const hdxNoAV = {
     },
 
     setupUI() {
+    	if(location.search.includes("none")){
+    		algOptionsDonePressed();
+    	}
 
     },
 

--- a/HighwayDataExaminer/hdxav.js
+++ b/HighwayDataExaminer/hdxav.js
@@ -186,6 +186,7 @@ const hdxAV = {
         const outerDetails = document.createElement("details");
         outerDetails.open = false;
         const outerSummary = document.createElement("summary");
+        outerSummary.setAttribute("id", "AVSelectionName");
         outerSummary.textContent = hdxNoAV.name;
         outerDetails.appendChild(outerSummary);
         s.appendChild(outerDetails);

--- a/HighwayDataExaminer/hdxinit.js
+++ b/HighwayDataExaminer/hdxinit.js
@@ -157,5 +157,6 @@ function HDXInit() {
     if(HDXQSIsSpecified("noav")){
     		document.getElementById("topControlPanelPseudo").style.display = "none";
         	document.getElementById("speedChanger").style.display = "none";
+        	document.getElementById("topCPConnections").style.display = "";
     	}
 }

--- a/HighwayDataExaminer/hdxinit.js
+++ b/HighwayDataExaminer/hdxinit.js
@@ -154,4 +154,8 @@ function HDXInit() {
 
     // Ensures that map is resized properly when window is resized
     window.addEventListener('resize', resizePanels);
+    if(HDXQSIsSpecified("noav")){
+    		document.getElementById("topControlPanelPseudo").style.display = "none";
+        	document.getElementById("speedChanger").style.display = "none";
+    	}
 }

--- a/HighwayDataExaminer/hdxjsfuncs.js
+++ b/HighwayDataExaminer/hdxjsfuncs.js
@@ -1211,3 +1211,19 @@ function exactDistanceInMiles(lat1, lon1, lat2, lon2) {
     var ang = Math.cos(lat1 * deg2rad) * Math.cos(lat2 * deg2rad) * Math.cos((lon1 - lon2)*deg2rad) + Math.sin(lat1 * deg2rad) * Math.sin(lat2 * deg2rad);
     return Math.acos(ang) * rad;
 }
+
+// callback for when the showWays checkbox is clicked
+function showConnectionsClicked() {
+
+    var showThem = document.getElementById('showConnections').checked;
+    if (showThem) {
+		for (var i = 0; i < graphEdges.length; i++) {
+			connections[i].addTo(map);
+		}
+    }
+    else {
+		for (var i = 0; i < graphEdges.length; i++) {
+	    	connections[i].remove();
+		}
+    }
+}

--- a/HighwayDataExaminer/index.php
+++ b/HighwayDataExaminer/index.php
@@ -175,6 +175,7 @@ will display
 	  </td><td>
 	    <div id="topControlPanelAV3">
 	      <input id="showMarkers" type="checkbox" name="Show Markers" onclick="showMarkersClicked()" checked />&nbsp;Show Markers<br>
+	      <span id="topCPConnections" style="display:none;"><input id="showConnections" type="checkbox" name="Show Connections" onclick="showConnectionsClicked()" checked />&nbsp;Show Connections<br></span>
 	      <span id="topControlPanelPseudo"><input id="pseudoCheckbox" type="checkbox" name="Pseudocode-level AV" checked onclick="showHidePseudocode();cleanupBreakpoints()" />&nbsp;Trace Pseudocode<br></span>
 	      <input id="datatablesCheckbox" type="checkbox" name="Datatables" checked onclick="showHideDatatables()" />&nbsp;Show Data Tables
 	    </div>	  

--- a/HighwayDataExaminer/index.php
+++ b/HighwayDataExaminer/index.php
@@ -140,7 +140,7 @@ will display
 <!-- Bar across the top -->
 <div class="menubar">
   <div id="info">
-    <button id="newGraph">New Graph</button><span id="filename"></span><br>
+    <button id="newGraph" onclick="document.getElementById('AVSelectionName').textContent=hdxNoAV.name;">New Graph</button><span id="filename"></span><br>
     <button id="newAlg">New Algorithm</button><span id="currentAlgorithm" onclick="resetPressed();cleanupBreakpoints();cleanupAVControlPanel()"></span>
   </div>
   <div id="topControlPanel">


### PR DESCRIPTION
Added to hdxinit in if statement to check for the noav condition, if so it would hide UI elements that are only needed when running an AV. Issue #553 

Added gradient to Get All Possible Traversals AV, for when a user hovers over the traversal listed in the AVCP. #586

When noav qs is present a new checkbox is a available to toggle on and off connections #484 and #491

Fixed a bug I found today where the circle on the distance click av is null it is attempted to be removed

Fixed a bug where AV Selection menu said one AV name but in all other ways behaved as if No AV was selected

Fixed a bug for hdxav-clickDist on the option for n closest vertices. Bug was that if the last vertex checked was one of the closest vertices, the color of the vertex would not be correct, but would be like one of the thrown away vertices.