### PR TITLE
Fixing open issues and some other non issue fixes

### DIFF
--- a/HighwayDataExaminer/hdx.css
+++ b/HighwayDataExaminer/hdx.css
@@ -1229,7 +1229,6 @@ p#pscode
 #title p#metalTitle
 {
     float: left;
-    max-width: 200px;
     color: white;
     font-family: Avenir, Arial, Helvetica, sans-serif;
     font-size: 36px;

--- a/HighwayDataExaminer/hdx.css
+++ b/HighwayDataExaminer/hdx.css
@@ -87,6 +87,8 @@
     border-spacing: 0;
     background-color: rgb(30, 179, 238);
     border: 2px solid black;
+    max-width:300px;
+    overflow-x: scroll;
 }
 
 

--- a/HighwayDataExaminer/hdxav-bftsp.js
+++ b/HighwayDataExaminer/hdxav-bftsp.js
@@ -32,6 +32,9 @@ const hdxBFTravelingSalesmanAV = {
 
     // number of paths visited so far
     pathCount: -1,
+    
+    // saves the 5 most recent times at which current iteration started
+    iterStartTime: [],
 
     avActions : [
         {
@@ -42,6 +45,9 @@ const hdxBFTravelingSalesmanAV = {
 		
                 // gets the staring vertex selected by the user as an integer
                 thisAV.startPoint = Number(document.getElementById("startPoint").value);
+                
+                thisAV.iterStartTime = [];
+                thisAV.iterStartTime.push(new Date().getTime());
 		
                 // we want to highlight the starting vertex
                 updateMarkerAndTable(thisAV.startPoint,
@@ -206,6 +212,23 @@ const hdxBFTravelingSalesmanAV = {
                     hdxAV.nextAction = "setMin";
                 }
                 
+                // recalculating time to completion
+                iterEndTime = new Date().getTime();
+                estTimeMs = ((iterEndTime - thisAV.iterStartTime[0])*thisAV.pathsRemaining)/(1000*thisAV.iterStartTime.length);
+                estTimeMin = Math.floor(estTimeMs/60);
+                estTimeSec = Math.floor(estTimeMs%60)
+                // standard time formatting for seconds
+                if(estTimeSec<10){
+                	estTimeNice=estTimeMin+":0"+estTimeSec;
+                }else{
+                	estTimeNice=estTimeMin+":"+estTimeSec;
+                }
+                hdxAVCP.update("timeToCompletion", "Estimated time to completion is : "+estTimeNice);
+                // updating iterStartTime, adding the newest time and removing the oldest if >5 values
+                thisAV.iterStartTime.push(iterEndTime);
+                if(thisAV.iterStartTime.length>5){
+                	thisAV.iterStartTime.shift();
+                }
             },
             logMessage: function(thisAV) {
                 return "Calculate distance of path " + thisAV.pathCount;
@@ -266,6 +289,7 @@ const hdxBFTravelingSalesmanAV = {
 			       thisAV.minDistance.toFixed(3) + " miles");
                 hdxAVCP.update('undiscovered', '');
                 hdxAVCP.update("currSum", "");
+                hdxAVCP.update("timeToCompletion", "");
 		
                 // rainbow constructor, used to make pattern so
                 // that users can better see the path in which the
@@ -388,6 +412,7 @@ const hdxBFTravelingSalesmanAV = {
 				  waypoints.length - 1);
 
 	// AVCP entries
+        hdxAVCP.add("timeToCompletion", visualSettings.discarded);
         hdxAVCP.add("undiscovered", visualSettings.undiscovered); 
         hdxAVCP.add("visiting", visualSettings.visiting);
         hdxAVCP.add("currSum", visualSettings.discovered);

--- a/HighwayDataExaminer/hdxav-clickDis.js
+++ b/HighwayDataExaminer/hdxav-clickDis.js
@@ -350,7 +350,7 @@ const hdxClickDisAV = {
         if(this.findVertices=="SLDistance"){
         	points = '<span>Closest point:</span>' +
             '<table id="closestPoint" style="width:100%;"></table>'+
-            '<span>Furthest point:</span>' +
+            '<br><span>Furthest point:</span>' +
             '<table id="furthestPoint" style="width:100%;"></table>';
         }else if(this.findVertices=="givenDistance"){
         	points = '<span id="pointCount">Number of points: 0</span>' +

--- a/HighwayDataExaminer/hdxav-clickDis.js
+++ b/HighwayDataExaminer/hdxav-clickDis.js
@@ -335,9 +335,9 @@ const hdxClickDisAV = {
         this.code += pcEntry(1, "d &larr; dist(referencePoint, v)", "distCalc");
         if(this.findVertices=="SLDistance"){
         	this.code += pcEntry(1, "if d < d<sub>closest</sub>", "checkSmallest");
-        	this.code += pcEntry(2, "d<sub>closest</sub> &larr; d<br>&emsp;&emsp;&emsp;&emsp;v<sub>closest</sub> &larr; v", "setSmallest");
+        	this.code += pcEntry(2, ["d<sub>closest</sub> &larr; d", "v<sub>closest</sub> &larr; v"], "setSmallest");
         	this.code += pcEntry(1, "else if d > d<sub>furthest</sub>", "checkFurthest");
-        	this.code += pcEntry(2, "d<sub>furthest</sub> &larr; d<br>&emsp;&emsp;&emsp;&emsp;v<sub>furthest</sub> &larr; v", "setFurthest");
+        	this.code += pcEntry(2, ["d<sub>furthest</sub> &larr; d", "v<sub>furthest</sub> &larr; v"], "setFurthest");
         }else if(this.findVertices=="givenDistance"){
         	this.code += pcEntry(1, "if d < maxDistance", "inRadiusCheck");
         	this.code += pcEntry(2, "closePoints.push(v)", "inRadius");

--- a/HighwayDataExaminer/hdxav-ordering.js
+++ b/HighwayDataExaminer/hdxav-ordering.js
@@ -61,7 +61,7 @@ const hdxOrderingAV = {
     avActions: [
         {
             label: "START",
-            comment: "",
+            comment: "Initializing AV variables, and establishes waypoint ordering method",
             code: function(thisAV) {
                 highlightPseudocode(this.label, visualSettings.visiting);
                 thisAV.nextToCheck = -1;
@@ -211,7 +211,7 @@ const hdxOrderingAV = {
 
         {
             label: "topForLoop",
-            comment: "",
+            comment: "Updates active vertices and changes map accordingly",
             code: function(thisAV) {
 
                 highlightPseudocode(this.label, visualSettings.visiting);
@@ -258,7 +258,7 @@ const hdxOrderingAV = {
         
         {
             label: "addEdge",
-            comment: "",
+            comment: "Adds edge with gradient coloring and updates AVCP",
             code: function(thisAV) {
                 highlightPseudocode(this.label, visualSettings.visiting);
                 let color = {
@@ -301,7 +301,7 @@ const hdxOrderingAV = {
         },          
         {
             label: "cleanup",
-            description: "",
+            description: "Updates AVCP with ordering information",
             code: function(thisAV) {
             // Partitioning
                 if (document.getElementById("calcparts").checked == true) {

--- a/HighwayDataExaminer/hdxavcp.js
+++ b/HighwayDataExaminer/hdxavcp.js
@@ -26,6 +26,7 @@ const hdxAVCP = {
 	infoBox.setAttribute('id', namePrefix + this.suffix);
 	infoBox.setAttribute('style', "color:" + vs.textColor +
                              "; background-color:" + vs.color);
+    infoBox.setAttribute("onclick", "collapseInnerTable(this)")
 	infoBoxtr.appendChild(infoBox);
 	infoBoxtr.style.display = "none";
 	this.rows.push(infoBoxtr);

--- a/HighwayDataExaminer/hdxjsfuncs.js
+++ b/HighwayDataExaminer/hdxjsfuncs.js
@@ -1234,10 +1234,8 @@ function collapseInnerTable(element){
 		if(child.tagName=="TABLE"){
 			if(child.style.display=="none"){
 				child.style.display="";
-				console.log("open");
 			}else{
 				child.style.display="none";
-				console.log("close");
 			}
 		}
 	}

--- a/HighwayDataExaminer/hdxjsfuncs.js
+++ b/HighwayDataExaminer/hdxjsfuncs.js
@@ -1212,7 +1212,7 @@ function exactDistanceInMiles(lat1, lon1, lat2, lon2) {
     return Math.acos(ang) * rad;
 }
 
-// callback for when the showWays checkbox is clicked
+// callback for when the showConnections checkbox is clicked
 function showConnectionsClicked() {
 
     var showThem = document.getElementById('showConnections').checked;
@@ -1226,4 +1226,19 @@ function showConnectionsClicked() {
 	    	connections[i].remove();
 		}
     }
+}
+
+// function to handle when avcp elments are clicked and when to expand or collapse
+function collapseInnerTable(element){
+	for(const child of element.children){
+		if(child.tagName=="TABLE"){
+			if(child.style.display=="none"){
+				child.style.display="";
+				console.log("open");
+			}else{
+				child.style.display="none";
+				console.log("close");
+			}
+		}
+	}
 }

--- a/HighwayDataExaminer/hdxpseudocode.js
+++ b/HighwayDataExaminer/hdxpseudocode.js
@@ -72,7 +72,7 @@ function pcEntry(indent, code, id) {
 
     let entry;
     if (id != "") {
-        entry = '<tr class="codeRow" custom-title="0 executions"><td id="' + id + '">';
+        entry = '<tr class="codeRow" custom-title="0 executions"><td id="' + id + '"><div style="overflow-x: scroll; white-space: nowrap;">';
     }
     else {
         entry = '<tr class="codeRow"><td>';
@@ -91,7 +91,7 @@ function pcEntry(indent, code, id) {
         }
         entry += code;
     }
-    entry += '</td></tr>';    
+    entry += '</div></td></tr>';    
     return entry;
 }
 

--- a/HighwayDataExaminer/hdxvertexselector.js
+++ b/HighwayDataExaminer/hdxvertexselector.js
@@ -57,7 +57,7 @@ function buildWaypointSelector(id, label, initVal){
 	contents +=`</datalist>`;
 	return contents;
 }
-// On change function for SelectorByLabel function, which translates label to number
+// On change function for buildWaypointSelector function, which translates label to number
 function labelToNumber(value, id){
 	for(let i=0;i<waypoints.length;i++){
 		let validV="#"+i+" "+waypoints[i].label;

--- a/HighwayDataExaminer/hdxvertexselector.js
+++ b/HighwayDataExaminer/hdxvertexselector.js
@@ -47,14 +47,24 @@ const hdxVertexSelector = {
 // id is the HTML element id for the input
 // label is the label for the control
 // initVal is the waypoint number to use for initialization
-function buildWaypointSelector(id,label,initVal) {
-        
-    return label + ' <input id="' + id +
-        '" onfocus="hdxVertexSelector.startSelection(\'' + id +
-        '\')" type="number" value="' + initVal + '" min="0" max="' +
-        (waypoints.length-1) + '" size="6" style="width: 7em" ' +
-        'onchange="waypointSelectorChanged(\'' + id + '\')"' +
-        '/>';        
+function buildWaypointSelector(id, label, initVal){
+	let contents = label + ` <input type="text" id="`+id+`" list="`+id+`List" onchange=
+	"labelToNumber(this.value, id)" value="`+initVal+`" onfocus="hdxVertexSelector.startSelection(\'' + id +
+        '\')"><datalist id="`+id+`List">`;
+	for(let i=0;i<waypoints.length;i++){
+		contents +=`<option value="#`+i+` `+waypoints[i].label+`">`;
+	}
+	contents +=`</datalist>`;
+	return contents;
+}
+// On change function for SelectorByLabel function, which translates label to number
+function labelToNumber(value, id){
+	for(let i=0;i<waypoints.length;i++){
+		let validV="#"+i+" "+waypoints[i].label;
+		if(value==validV){
+			document.getElementById(id).value=i;
+		}
+	}
 }
 
 // Same as buildWaypointSelector but is used for conditional

--- a/HighwayDataExaminer/index.php
+++ b/HighwayDataExaminer/index.php
@@ -174,10 +174,10 @@ will display
 	    </select>
 	  </td><td>
 	    <div id="topControlPanelAV3">
-	      <input id="showMarkers" type="checkbox" name="Show Markers" onclick="showMarkersClicked()" checked />&nbsp;Show Markers<br>
-	      <span id="topCPConnections" style="display:none;"><input id="showConnections" type="checkbox" name="Show Connections" onclick="showConnectionsClicked()" checked />&nbsp;Show Connections<br></span>
-	      <span id="topControlPanelPseudo"><input id="pseudoCheckbox" type="checkbox" name="Pseudocode-level AV" checked onclick="showHidePseudocode();cleanupBreakpoints()" />&nbsp;Trace Pseudocode<br></span>
-	      <input id="datatablesCheckbox" type="checkbox" name="Datatables" checked onclick="showHideDatatables()" />&nbsp;Show Data Tables
+	      <input id="showMarkers" type="checkbox" name="Show Markers" onclick="showMarkersClicked()" checked /><label for="showMarkers">&nbsp;Show Markers</label><br>
+	      <span id="topCPConnections" style="display:none;"><input id="showConnections" type="checkbox" name="Show Connections" onclick="showConnectionsClicked()" checked /><label for="showConnections">&nbsp;Show Connections</label><br></span>
+	      <span id="topControlPanelPseudo"><input id="pseudoCheckbox" type="checkbox" name="Pseudocode-level AV" checked onclick="showHidePseudocode();cleanupBreakpoints()" /><label for="pseudoCheckbox">&nbsp;Trace Pseudocode</label><br></span>
+	      <input id="datatablesCheckbox" type="checkbox" name="Datatables" checked onclick="showHideDatatables()" /><label for="datatablesCheckbox">&nbsp;Show Data Tables</label>
 	    </div>	  
 	  </td>
 	</tr>

--- a/HighwayDataExaminer/index.php
+++ b/HighwayDataExaminer/index.php
@@ -185,7 +185,7 @@ will display
     </table>
   </div>
   <div id="title">
-    <p id="metalTitle">METAL&nbsp;HDX</p>
+    <p id="metalTitle"><img src="MetalBetaLogoSmall.png" height="40px" style="padding-left:1rem" alt="M">ETAL&nbsp;HDX</p>
   </div>
 </div>
 


### PR DESCRIPTION
#523 migrated to a new vertex selection method that uses data list and allows complete on vertex labels.

#17 Made tables in the AVCP collapsable so that large tables with many rows take up less space.

#508 All comment fields now have comments that describes what the state does.

#530 New count down time with estimated time until completion displaying as m:ss. This time to completion approximation is done based on the last 5 iterations of BFTSP as to smooth out the estimated time. While also throwing away older iterations so that if the user changes the run speed, the old speed will not always be factored in the for the rest of execution, or if the machine is paused for sometime and then unpaused.

#227 Pseudo code lines no longer wrap, instead when lines are longer than allowed, there is a horizontal scroll bar.

Added label tags to checkboxes, this was not an issue, just something I noticed and thought it would be nice to allow users to click on the text, have that check and uncheck the box.

Added a new row between furthest and closest point information on clickDis AV so that it looked better when the box is collapsed given the new implementation of issue #17.

Organized pseudo code in clickDist av to use intended pseudo code formatting for new lines in same state.

METAL Logo added to index.